### PR TITLE
修复 Safari 中 drawer 无法显示的问题

### DIFF
--- a/example/App.san
+++ b/example/App.san
@@ -170,7 +170,6 @@ export default {
     position: fixed
     top: 0
     bottom: 0
-    overflow: auto
 
 .example-drawer-appbar
     background: $md-colors.blue500


### PR DESCRIPTION
## 原因

Safari 中两个样式为 `position: fixed` 的元素产生父子关系时，如果父元素没有指定宽高并且样式设置 `overflow: auto`，子元素无法被正常渲染。

## 复现用例

http://jsdm.com/anon/paint/aT67w