### PR TITLE
fix dropdownMenu dynamic items

### DIFF
--- a/example/Menu/DropdownMenu.md
+++ b/example/Menu/DropdownMenu.md
@@ -135,3 +135,47 @@ export default {
 };
 </script>
 ```
+
+动态Items：有时业务可能会更改组件的选项列表，可以动态设置选项。
+
+```san 动态Items：
+<template>
+<section>
+    <sm-dropdown-menu value="{=value=}" maxHeight="{{200}}" autoWidth="{{false}}">
+        <sm-menu-item
+            s-for="item in items"
+            value="{{item.value}}"
+            label="{{item.label}}" />
+    </sm-dropdown-menu>
+</section>
+</template>
+<script>
+import {MenuItem, DropDownMenu} from '../../src/Menu';
+import Icon from '../../src/Icon';
+import Divider from '../../src/Divider';
+import '../../src/Menu/index.styl';
+import '../../src/Icon/Icon.styl';
+import '../../src/Divider/Divider.styl';
+
+export default {
+    components: {
+        'sm-dropdown-menu': DropDownMenu,
+        'sm-menu-item': MenuItem,
+        'sm-icon': Icon,
+        'sm-divider': Divider
+    },
+    inited() {
+        this.watch('value', val => {
+            let items = Array.from({length: 5}).map((_, i) => ({value: i, label: `第${i}项`}))
+            this.data.set('items', items);
+        });
+    },
+    initData() {
+        return {
+            value: '',
+            items: Array.from({length: 10}).map((_, i) => ({value: i, label: `第${i}项`}))
+        };
+    }
+};
+</script>
+```

--- a/src/Menu/DropDownMenu.js
+++ b/src/Menu/DropDownMenu.js
@@ -58,7 +58,7 @@ export default class DropDownMenu extends Component {
     };
 
     static messages = {
-        [C.MENU_ITEM_INITED](e) {
+        [C.MENU_ITEM_ATTACHED](e) {
             this.items.push(e.target);
             let targetData = e.target.data;
             let {value, label, title} = targetData.get();
@@ -85,6 +85,11 @@ export default class DropDownMenu extends Component {
             });
             this.data.set('open', false);
             this.fire('change', value);
+        },
+        [C.MENU_ITEM_DETACHED](e) {
+            this.items.splice(this.items.indexOf(e.target), 1);
+            let targetData = e.target.data;
+            let {value, label, title} = targetData.get();
         },
         [C.MENU_ITEM_CLICK]() {
             this.data.set('open', false);


### PR DESCRIPTION
When use `dropdownMenu`, found it not support `dynamic` items. If you change the data items, it throw error.
The code just take care of the `inited` event, and then put the item in the items, but when data items change, the `detached` event trigger, show remove the `item` from the data `items`.  I thought it would be more suitable using the 'attached' event instead of 'inited' event.