### PR TITLE
dropDownMenu 在 option 模式下，已选项点击应该仍然触发选择事件

### DIFF
--- a/src/Menu/DropDownMenu.js
+++ b/src/Menu/DropDownMenu.js
@@ -73,9 +73,6 @@ export default class DropDownMenu extends Component {
         },
         [C.MENU_ITEM_OPTION_SELECTED]({target}) {
             let {value, label, title} = target.data.get();
-            if (this.data.get('value') === value) {
-                return;
-            }
             this.data.set('value', value);
             this.data.set('displayText', label || title || value);
             this.items.forEach(item => {

--- a/src/Menu/MenuItem.js
+++ b/src/Menu/MenuItem.js
@@ -281,16 +281,13 @@ export default class MenuItem extends Component {
             }
 
             case 'option': {
+                // 更新自己的 selected 状态
+                this.data.set('selected', true);
 
-                if (!selected) {
-                    // 更新自己的 selected 状态
-                    this.data.set('selected', true);
+                // 同步其他 menu-item，解除 selected 状态
+                this.dispatch(C.MENU_ITEM_OPTION_SELECTED, {value});
 
-                    // 同步其他 menu-item，解除 selected 状态
-                    this.dispatch(C.MENU_ITEM_OPTION_SELECTED, {value});
-
-                    this.fire('change');
-                }
+                this.fire('change');
 
                 return;
             }


### PR DESCRIPTION
目前dropDownMenu在option模式下，用来模拟单选select。在一些场景下，表单是联动的。比如下拉选择此时选择是状态a，对应的关联组件状态是A，如果用户更改了关联组件状态到B。此时用户用通过下拉选择a来重置关联组件状态到A。但是已选项不可点击。进而无法触发选择事件。
更改为下来选择模式，已选项仍可点击更符合select的特性。