### PR TITLE
修复Configure Table组件的selected属性初始渲染问题，并添加disabled属性

### DIFF
--- a/example/Table.md
+++ b/example/Table.md
@@ -145,7 +145,7 @@ export default {
                 </sm-tr>
             </sm-thead>
             <sm-tbody>
-                <sm-tr san-for="item in persons" selected="{=item.selected=}">
+                <sm-tr san-for="item in persons" selected="{=item.selected=}" disabled="{{item.disabled}}">
                     <sm-td>{{item.name}}</sm-td>
                     <sm-td>{{item.city}}</sm-td>
                     <sm-td>{{item.birthday}}</sm-td>
@@ -179,7 +179,8 @@ export default {
                     name: 'erik',
                     birthday: '1984-01-01',
                     city: 'BeiJing',
-                    selected: true
+                    selected: true,
+                    disabled: true
                 },
                 {
                     name: 'otakustay',
@@ -308,7 +309,8 @@ export default {
                     name: 'erik',
                     birthday: '1984-01-01',
                     city: 'BeiJing',
-                    selected: false
+                    selected: false,
+                    disabled: true
                 },
                 {
                     name: 'otakustay',

--- a/src/Table/ConfigurableTable.js
+++ b/src/Table/ConfigurableTable.js
@@ -45,7 +45,7 @@ export default class ConfigurableTable extends Table {
                 </ui-tr>
             </ui-thead>
             <ui-tbody>
-                <ui-tr san-for="item in data">
+                <ui-tr san-for="item in data" selected="{=item.selected=}" disabled="{{item.disabled}}">
                     <ui-td san-for="field in fields">{{field | renderField(item)}}</ui-td>
                 </ui-tr>
             </ui-tbody>

--- a/src/Table/TR.js
+++ b/src/Table/TR.js
@@ -24,10 +24,14 @@ export default class TR extends san.Component {
                 san-if="tableSelectable === 'multi'"
                 class="sm-table-col-select">
                 <sm-checkbox
-                    s-if="tableSelectable"
+                    s-if="disabled"
+                    checked="{{checked}}"
+                    disabled/>
+                <sm-checkbox
+                    s-else
                     checked="{{checked}}"
                     value="ON"
-                    on-input-change="select($event)" />
+                    on-input-change="select($event)"/>
             </sm-th>
             <sm-th
                 san-if="tableSelectable === 'single'"

--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -32,9 +32,18 @@ export default class Table extends san.Component {
             let selectAll = e.value;
 
             this.tbody.eachItem((tr, index) => {
-                tr.data.set('selected', selectAll);
-                if (selectAll) {
-                    selected.push(index);
+                let trDisabled = tr.data.get('disabled');
+                if (!trDisabled) {
+                    tr.data.set('selected', selectAll);
+                    if (selectAll) {
+                        selected.push(index);
+                    }
+                }
+                else {
+                    let trSelected = tr.data.get('selected');
+                    if (trSelected) {
+                        selected.push(index);
+                    }
                 }
             });
 


### PR DESCRIPTION
目前Configure Table组件在selectable为multi的场景下，即使传入data数据时设置selected属性值为true，也无法渲染出默认打勾。原因在于ConfigureTable在实现过程中，没有向TR组件传入selected属性，因此需要加上。
另外，由于在日常业务场景中，有些表格项默认是不能改变的，因此Configure Table组件在selecteable为multi的场景下，需要添加经data传入数据的disabled属性，因此加上了此功能