### PR TITLE
fix:Dialog中味调用Layer的attched

### DIFF
--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -91,6 +91,7 @@ export default class Dialog extends Layer {
     }
 
     attached() {
+        super.attached();
         this.watch('open', open => {
             this.lockBodyScroll(open);
         });


### PR DESCRIPTION
Dialog继承自Layer，Layer中的attched将组件至于body之下，我理解应该是为了解决父级元素中有overflow hidden的问题。

但是这里没有调用，感觉应该算是一个bug。