### PR TITLE
fix(Chip): fix stylus SyntaxError "Unknown word - padding"

### DIFF
--- a/src/Chip/Chip.styl
+++ b/src/Chip/Chip.styl
@@ -17,7 +17,6 @@ alternateTextColor = invert(textColor)
     display: inline-flex
     align-items center
     padding 0 12px
-    padding
     cursor default
     color: rgba(textColor, 87%)
     background-color: darken(alternateTextColor, 12%)


### PR DESCRIPTION
[san-devtool](https://github.com/baidu/san-devtool) 在使用 san-mui 的 Chip 组件时，会因为 "padding" 这行代码产生 SyntaxError 的报错信息（构建工具版本 Webpack@4.43.0, stylus-loader@3.0.2 , css-loader@3.5.3, san-mui@1.1.5）。报错信息如下：

ERROR in ./node_modules/san-mui/lib/Chip/Chip.styl (./node_modules/css-loader/dist/cjs.js!./node_modules/postcss-loader/src!./node_modules/stylus-loader!./node_modules/san-mui/lib/Chip/Chip.styl)
Module build failed (from ./node_modules/postcss-loader/src/index.js):
SyntaxError

(41:3) Unknown word

 39 |   padding: 0 12px;
  40 | padding
\> 41 |   cursor: default;

结合代码上下文，删除掉第 40 行的 padding 即解决了这个问题。